### PR TITLE
Show test execution duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Prettify the `xcodebuild` output | :white_check_mark: | :no_entry_sign:
 Generate JUnit reports | :white_check_mark: | :white_check_mark:
 Generate HTML reports | :white_check_mark: | :no_entry_sign:
 Works when the `xcodebuild` output format changed | :no_entry_sign: | :white_check_mark:
-Show test execution duration | :white_check_mark: | :no_entry_sign:
+Show test execution duration | :white_check_mark: | :white_check_mark:
 Speed | :car: | :rocket:
 
 [xcpretty](https://github.com/supermarin/xcpretty) is a great piece of software that is used across all [fastlane tools](https://fastlane.tools). `trainer` was built to have the minimum code to generate JUnit reports for your CI system.

--- a/lib/assets/junit.xml.erb
+++ b/lib/assets/junit.xml.erb
@@ -6,9 +6,9 @@
 
 <testsuites tests="<%= number_of_tests %>" failures="<%= number_of_failures %>">
   <% @results.each do |testsuite| %>
-    <testsuite name=<%= testsuite[:target_name].encode(:xml => :attr) %> tests="<%= testsuite[:number_of_tests] %>" failures="<%= testsuite[:number_of_failures] %>">
+    <testsuite name=<%= testsuite[:target_name].encode(:xml => :attr) %> tests="<%= testsuite[:number_of_tests] %>" failures="<%= testsuite[:number_of_failures] %>" time="<%= testsuite[:duration] %>">
       <% testsuite[:tests].each do |test| %>
-        <testcase classname=<%= test[:test_group].encode(:xml => :attr) %> name=<%= test[:name].encode(:xml => :attr) %>>
+        <testcase classname=<%= test[:test_group].encode(:xml => :attr) %> name=<%= test[:name].encode(:xml => :attr) %> time="<%= test[:duration] %>">
           <% (test[:failures] || []).each do |failure| %>
             <failure message=<%= failure[:failure_message].encode(:xml => :attr) %>>
             </failure>

--- a/lib/trainer/test_parser.rb
+++ b/lib/trainer/test_parser.rb
@@ -78,7 +78,8 @@ module Trainer
         # => [{"Subtests"=>
         #  [{"Subtests"=>
         #     [{"Subtests"=>
-        #        [{"TestIdentifier"=>"Unit/testExample()",
+        #        [{"Duration"=>0.4,
+        #          "TestIdentifier"=>"Unit/testExample()",
         #          "TestName"=>"testExample()",
         #          "TestObjectClass"=>"IDESchemeActionTestSummary",
         #          "TestStatus"=>"Success",
@@ -107,6 +108,7 @@ module Trainer
           project_path: testable_summary["ProjectPath"],
           target_name: testable_summary["TargetName"],
           test_name: testable_summary["TestName"],
+          duration: testable_summary["Tests"].map {|current_test| current_test["Duration"] }.inject(:+).to_s,
           tests: unfold_tests(testable_summary["Tests"]).collect do |current_test|
             current_row = {
               identifier: current_test["TestIdentifier"],
@@ -114,7 +116,8 @@ module Trainer
               name: current_test["TestName"],
               object_class: current_test["TestObjectClass"],
               status: current_test["TestStatus"],
-              guid: current_test["TestSummaryGUID"]
+              guid: current_test["TestSummaryGUID"],
+              duration: current_test["Duration"].to_s
             }
             if current_test["FailureSummaries"]
               current_row[:failures] = current_test["FailureSummaries"].collect do |current_failure|

--- a/lib/trainer/test_parser.rb
+++ b/lib/trainer/test_parser.rb
@@ -47,7 +47,7 @@ module Trainer
 
       self.file_content = File.read(path)
       self.raw_json = Plist.parse_xml(self.file_content)
-      return if self.raw_json["FormatVersion"].to_s.length == 0 # maybe that's a useless plist file
+      return if self.raw_json["FormatVersion"].to_s.length.zero? # maybe that's a useless plist file
 
       ensure_file_valid!
       parse_content
@@ -60,7 +60,7 @@ module Trainer
 
     # @return [Bool] were all tests successful? Is false if at least one test failed
     def tests_successful?
-      self.data.collect { |a| a[:number_of_failures] }.all? { |a| a == 0 }
+      self.data.collect { |a| a[:number_of_failures] }.all?(&:zero?)
     end
 
     private
@@ -71,44 +71,45 @@ module Trainer
       UI.user_error!("Format version '#{format_version}' is not supported, must be #{supported_versions.join(', ')}") unless supported_versions.include?(format_version)
     end
 
+    # Converts the raw plist test structure into something that's easier to enumerate
+    def unfold_tests(data)
+      # `data` looks like this
+      # => [{"Subtests"=>
+      #  [{"Subtests"=>
+      #     [{"Subtests"=>
+      #        [{"Duration"=>0.4,
+      #          "TestIdentifier"=>"Unit/testExample()",
+      #          "TestName"=>"testExample()",
+      #          "TestObjectClass"=>"IDESchemeActionTestSummary",
+      #          "TestStatus"=>"Success",
+      #          "TestSummaryGUID"=>"4A24BFED-03E6-4FBE-BC5E-2D80023C06B4"},
+      #         {"FailureSummaries"=>
+      #           [{"FileName"=>"/Users/krausefx/Developer/themoji/Unit/Unit.swift",
+      #             "LineNumber"=>34,
+      #             "Message"=>"XCTAssertTrue failed - ",
+      #             "PerformanceFailure"=>false}],
+      #          "TestIdentifier"=>"Unit/testExample2()",
+
+      tests = []
+      data.each do |current_hash|
+        if current_hash["Subtests"]
+          tests += unfold_tests(current_hash["Subtests"])
+        end
+        if current_hash["TestStatus"]
+          tests << current_hash
+        end
+      end
+      return tests
+    end
+
     # Convert the Hashes and Arrays in something more useful
     def parse_content
-      def unfold_tests(data)
-        # `data` looks like this
-        # => [{"Subtests"=>
-        #  [{"Subtests"=>
-        #     [{"Subtests"=>
-        #        [{"Duration"=>0.4,
-        #          "TestIdentifier"=>"Unit/testExample()",
-        #          "TestName"=>"testExample()",
-        #          "TestObjectClass"=>"IDESchemeActionTestSummary",
-        #          "TestStatus"=>"Success",
-        #          "TestSummaryGUID"=>"4A24BFED-03E6-4FBE-BC5E-2D80023C06B4"},
-        #         {"FailureSummaries"=>
-        #           [{"FileName"=>"/Users/krausefx/Developer/themoji/Unit/Unit.swift",
-        #             "LineNumber"=>34,
-        #             "Message"=>"XCTAssertTrue failed - ",
-        #             "PerformanceFailure"=>false}],
-        #          "TestIdentifier"=>"Unit/testExample2()",
-
-        tests = []
-        data.each do |current_hash|
-          if current_hash["Subtests"]
-            tests += unfold_tests(current_hash["Subtests"])
-          end
-          if current_hash["TestStatus"]
-            tests << current_hash
-          end
-        end
-        return tests
-      end
-
       self.data = self.raw_json["TestableSummaries"].collect do |testable_summary|
         summary_row = {
           project_path: testable_summary["ProjectPath"],
           target_name: testable_summary["TargetName"],
           test_name: testable_summary["TestName"],
-          duration: testable_summary["Tests"].map {|current_test| current_test["Duration"] }.inject(:+),
+          duration: testable_summary["Tests"].map { |current_test| current_test["Duration"] }.inject(:+),
           tests: unfold_tests(testable_summary["Tests"]).collect do |current_test|
             current_row = {
               identifier: current_test["TestIdentifier"],

--- a/lib/trainer/test_parser.rb
+++ b/lib/trainer/test_parser.rb
@@ -108,7 +108,7 @@ module Trainer
           project_path: testable_summary["ProjectPath"],
           target_name: testable_summary["TargetName"],
           test_name: testable_summary["TestName"],
-          duration: testable_summary["Tests"].map {|current_test| current_test["Duration"] }.inject(:+).to_s,
+          duration: testable_summary["Tests"].map {|current_test| current_test["Duration"] }.inject(:+),
           tests: unfold_tests(testable_summary["Tests"]).collect do |current_test|
             current_row = {
               identifier: current_test["TestIdentifier"],
@@ -117,7 +117,7 @@ module Trainer
               object_class: current_test["TestObjectClass"],
               status: current_test["TestStatus"],
               guid: current_test["TestSummaryGUID"],
-              duration: current_test["Duration"].to_s
+              duration: current_test["Duration"]
             }
             if current_test["FailureSummaries"]
               current_row[:failures] = current_test["FailureSummaries"].collect do |current_failure|

--- a/spec/fixtures/Valid1.junit
+++ b/spec/fixtures/Valid1.junit
@@ -4,7 +4,7 @@
         <testcase classname="Unit" name="testExample()">
         </testcase>
         <testcase classname="Unit" name="testExample2()">
-            <failure message="XCTAssertTrue failed - /Users/krausefx/Developer/themoji/Unit/Unit.swift:34">
+            <failure message="XCTAssertTrue failed - /Users/liamnichols/Code/Local/Trainer/Unit/Unit.swift:19">
             </failure>
         </testcase>
         <testcase classname="Unit" name="testPerformanceExample()">

--- a/spec/fixtures/Valid1.junit
+++ b/spec/fixtures/Valid1.junit
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="3" failures="1">
-    <testsuite name="Unit" tests="3" failures="1">
-        <testcase classname="Unit" name="testExample()">
+    <testsuite name="Unit" tests="3" failures="1" time="0.4">
+        <testcase classname="Unit" name="testExample()" time="0.1">
         </testcase>
-        <testcase classname="Unit" name="testExample2()">
+        <testcase classname="Unit" name="testExample2()" time="0.1">
             <failure message="XCTAssertTrue failed - /Users/liamnichols/Code/Local/Trainer/Unit/Unit.swift:19">
             </failure>
         </testcase>
-        <testcase classname="Unit" name="testPerformanceExample()">
+        <testcase classname="Unit" name="testPerformanceExample()" time="0.4">
         </testcase>
     </testsuite>
 </testsuites>

--- a/spec/fixtures/Valid1.junit
+++ b/spec/fixtures/Valid1.junit
@@ -7,7 +7,7 @@
             <failure message="XCTAssertTrue failed - /Users/liamnichols/Code/Local/Trainer/Unit/Unit.swift:19">
             </failure>
         </testcase>
-        <testcase classname="Unit" name="testPerformanceExample()" time="0.4">
+        <testcase classname="Unit" name="testPerformanceExample()" time="0.2">
         </testcase>
     </testsuite>
 </testsuites>

--- a/spec/fixtures/Valid1.plist
+++ b/spec/fixtures/Valid1.plist
@@ -15,15 +15,15 @@
 			<key>CPUKind</key>
 			<string>Intel Core i7</string>
 			<key>CPUSpeedInMHz</key>
-			<integer>2300</integer>
+			<integer>2200</integer>
 			<key>Identifier</key>
-			<string>E93E5E8E-9DA2-5D26-AFAB-AAAAC0E7AC17</string>
+			<string>5866D528-1062-59B5-9789-7735BA8D55C7</string>
 			<key>IsConcreteDevice</key>
 			<true/>
 			<key>LogicalCPUCoresPerPackage</key>
 			<integer>8</integer>
 			<key>ModelCode</key>
-			<string>MacBookPro11,3</string>
+			<string>MacBookPro11,2</string>
 			<key>ModelName</key>
 			<string>MacBook Pro</string>
 			<key>ModelUTI</key>
@@ -33,9 +33,9 @@
 			<key>NativeArchitecture</key>
 			<string>x86_64h</string>
 			<key>OperatingSystemVersion</key>
-			<string>10.11.5</string>
+			<string>10.11.6</string>
 			<key>OperatingSystemVersionWithBuildNumber</key>
-			<string>10.11.5 (15F34)</string>
+			<string>10.11.6 (15G31)</string>
 			<key>PhysicalCPUCoresPerPackage</key>
 			<integer>4</integer>
 			<key>Platform</key>
@@ -43,35 +43,35 @@
 				<key>Identifier</key>
 				<string>com.apple.platform.macosx</string>
 				<key>Name</key>
-				<string>OS X</string>
+				<string>macOS</string>
 			</dict>
 			<key>RAMSizeInMegabytes</key>
 			<integer>16384</integer>
 		</dict>
 		<key>Name</key>
-		<string>iPhone 6</string>
+		<string>iPhone SE</string>
 		<key>TargetArchitecture</key>
 		<string>x86_64</string>
 		<key>TargetDevice</key>
 		<dict>
 			<key>Identifier</key>
-			<string>C506E86B-40D9-43D2-95FB-AAAADF799AAB</string>
+			<string>252CADC1-E488-4506-B293-892F59253C63</string>
 			<key>IsConcreteDevice</key>
 			<true/>
 			<key>ModelCode</key>
-			<string>iPhone7,2</string>
+			<string>iPhone8,4</string>
 			<key>ModelName</key>
-			<string>iPhone 6</string>
+			<string>iPhone SE</string>
 			<key>ModelUTI</key>
-			<string>com.apple.iphone-6-b4b5b9</string>
+			<string>com.apple.iphone-se-a1662-aeb1b8</string>
 			<key>Name</key>
-			<string>iPhone 6</string>
+			<string>iPhone SE</string>
 			<key>NativeArchitecture</key>
 			<string>x86_64</string>
 			<key>OperatingSystemVersion</key>
-			<string>9.3</string>
+			<string>10.0</string>
 			<key>OperatingSystemVersionWithBuildNumber</key>
-			<string>9.3 (13E230)</string>
+			<string>10.0 (14A5339a)</string>
 			<key>Platform</key>
 			<dict>
 				<key>Identifier</key>
@@ -83,20 +83,20 @@
 		<key>TargetSDK</key>
 		<dict>
 			<key>Identifier</key>
-			<string>iphonesimulator9.3</string>
+			<string>iphonesimulator10.0</string>
 			<key>IsInternal</key>
 			<false/>
 			<key>Name</key>
-			<string>Simulator - iOS 9.3</string>
+			<string>Simulator - iOS 10.0</string>
 			<key>OperatingSystemVersion</key>
-			<string>9.3</string>
+			<string>10.0</string>
 		</dict>
 	</dict>
 	<key>TestableSummaries</key>
 	<array>
 		<dict>
 			<key>ProjectPath</key>
-			<string>Themoji.xcodeproj</string>
+			<string>Trainer.xcodeproj</string>
 			<key>TargetName</key>
 			<string>Unit</string>
 			<key>TestName</key>
@@ -106,15 +106,23 @@
 			<key>Tests</key>
 			<array>
 				<dict>
+					<key>Duration</key>
+					<real>0.28409099578857422</real>
 					<key>Subtests</key>
 					<array>
 						<dict>
+							<key>Duration</key>
+							<real>0.28289800882339478</real>
 							<key>Subtests</key>
 							<array>
 								<dict>
+									<key>Duration</key>
+									<real>0.28223299980163574</real>
 									<key>Subtests</key>
 									<array>
 										<dict>
+											<key>Duration</key>
+											<real>0.0014020204544067383</real>
 											<key>TestIdentifier</key>
 											<string>Unit/testExample()</string>
 											<key>TestName</key>
@@ -124,16 +132,18 @@
 											<key>TestStatus</key>
 											<string>Success</string>
 											<key>TestSummaryGUID</key>
-											<string>4A24BFED-03E6-4FBE-BC5E-2D80023C06B4</string>
+											<string>6840EEB8-3D7A-4B2D-9A45-6955DC11D32B</string>
 										</dict>
 										<dict>
+											<key>Duration</key>
+											<real>0.0083320140838623047</real>
 											<key>FailureSummaries</key>
 											<array>
 												<dict>
 													<key>FileName</key>
-													<string>/Users/krausefx/Developer/themoji/Unit/Unit.swift</string>
+													<string>/Users/liamnichols/Code/Local/Trainer/Unit/Unit.swift</string>
 													<key>LineNumber</key>
-													<integer>34</integer>
+													<integer>19</integer>
 													<key>Message</key>
 													<string>XCTAssertTrue failed - </string>
 													<key>PerformanceFailure</key>
@@ -149,9 +159,11 @@
 											<key>TestStatus</key>
 											<string>Failure</string>
 											<key>TestSummaryGUID</key>
-											<string>B6AE5BAD-2F01-4D34-BEC8-6AB07472A13B</string>
+											<string>B2EB311E-ED8D-4DAD-8AF0-A455A20855DF</string>
 										</dict>
 										<dict>
+											<key>Duration</key>
+											<real>0.27134197950363159</real>
 											<key>PerformanceMetrics</key>
 											<array>
 												<dict>
@@ -167,16 +179,16 @@
 													<real>0.10000000000000001</real>
 													<key>Measurements</key>
 													<array>
-														<real>4.0450000000000002e-06</real>
-														<real>1.0720000000000001e-06</real>
-														<real>5.7599999999999997e-07</real>
-														<real>4.7599999999999997e-07</real>
-														<real>3.84e-07</real>
-														<real>3.77e-07</real>
-														<real>4.08e-07</real>
-														<real>4.03e-07</real>
-														<real>4.03e-07</real>
-														<real>3.7599999999999998e-07</real>
+														<real>0.0036532639999999998</real>
+														<real>0.00042886299999999998</real>
+														<real>0.00042833299999999998</real>
+														<real>0.00056399100000000001</real>
+														<real>0.00043089700000000002</real>
+														<real>0.00038601199999999998</real>
+														<real>0.0012799319999999999</real>
+														<real>0.00039773299999999999</real>
+														<real>0.0010501919999999999</real>
+														<real>0.0011717120000000001</real>
 													</array>
 													<key>Name</key>
 													<string>Time</string>
@@ -193,7 +205,7 @@
 											<key>TestStatus</key>
 											<string>Success</string>
 											<key>TestSummaryGUID</key>
-											<string>777C5F98-023B-4F99-B98D-20DDE724160E</string>
+											<string>72D0B210-939D-4751-966F-986B6CB2660C</string>
 										</dict>
 									</array>
 									<key>TestIdentifier</key>

--- a/spec/fixtures/Valid1.plist
+++ b/spec/fixtures/Valid1.plist
@@ -107,22 +107,22 @@
 			<array>
 				<dict>
 					<key>Duration</key>
-					<real>0.28409099578857422</real>
+					<real>0.4</real>
 					<key>Subtests</key>
 					<array>
 						<dict>
 							<key>Duration</key>
-							<real>0.28289800882339478</real>
+							<real>0.4</real>
 							<key>Subtests</key>
 							<array>
 								<dict>
 									<key>Duration</key>
-									<real>0.28223299980163574</real>
+									<real>0.4</real>
 									<key>Subtests</key>
 									<array>
 										<dict>
 											<key>Duration</key>
-											<real>0.0014020204544067383</real>
+											<real>0.1</real>
 											<key>TestIdentifier</key>
 											<string>Unit/testExample()</string>
 											<key>TestName</key>
@@ -136,7 +136,7 @@
 										</dict>
 										<dict>
 											<key>Duration</key>
-											<real>0.0083320140838623047</real>
+											<real>0.1</real>
 											<key>FailureSummaries</key>
 											<array>
 												<dict>
@@ -163,7 +163,7 @@
 										</dict>
 										<dict>
 											<key>Duration</key>
-											<real>0.27134197950363159</real>
+											<real>0.2</real>
 											<key>PerformanceMetrics</key>
 											<array>
 												<dict>
@@ -174,21 +174,21 @@
 													<key>MaxPercentRelativeStandardDeviation</key>
 													<integer>10</integer>
 													<key>MaxRegression</key>
-													<real>0.10000000000000001</real>
+													<real>0.1</real>
 													<key>MaxStandardDeviation</key>
-													<real>0.10000000000000001</real>
+													<real>0.1</real>
 													<key>Measurements</key>
 													<array>
-														<real>0.0036532639999999998</real>
-														<real>0.00042886299999999998</real>
-														<real>0.00042833299999999998</real>
-														<real>0.00056399100000000001</real>
-														<real>0.00043089700000000002</real>
-														<real>0.00038601199999999998</real>
-														<real>0.0012799319999999999</real>
-														<real>0.00039773299999999999</real>
-														<real>0.0010501919999999999</real>
-														<real>0.0011717120000000001</real>
+														<real>0.003653264</real>
+														<real>0.000428863</real>
+														<real>0.000428333</real>
+														<real>0.000563991</real>
+														<real>0.000430897</real>
+														<real>0.000386012</real>
+														<real>0.001279932</real>
+														<real>0.000397733</real>
+														<real>0.001050192</real>
+														<real>0.001171712</real>
 													</array>
 													<key>Name</key>
 													<string>Time</string>

--- a/spec/fixtures/Valid2.junit
+++ b/spec/fixtures/Valid2.junit
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="3" failures="0">
-    <testsuite name="Unit" tests="3" failures="0">
-        <testcase classname="Unit" name="testExample()">
+    <testsuite name="Unit" tests="3" failures="0" time="0.4">
+        <testcase classname="Unit" name="testExample()" time="0.1">
         </testcase>
-        <testcase classname="Unit" name="testExample2()">
+        <testcase classname="Unit" name="testExample2()" time="0.1">
         </testcase>
-        <testcase classname="Unit" name="testPerformanceExample()">
+        <testcase classname="Unit" name="testPerformanceExample()" time="0.2">
         </testcase>
     </testsuite>
 </testsuites>

--- a/spec/fixtures/Valid2.plist
+++ b/spec/fixtures/Valid2.plist
@@ -15,15 +15,15 @@
 			<key>CPUKind</key>
 			<string>Intel Core i7</string>
 			<key>CPUSpeedInMHz</key>
-			<integer>2300</integer>
+			<integer>2200</integer>
 			<key>Identifier</key>
-			<string>E93E5E8E-9DA2-5D26-AFAB-F77AC0E7AC17</string>
+			<string>5866D528-1062-59B5-9789-7735BA8D55C7</string>
 			<key>IsConcreteDevice</key>
 			<true/>
 			<key>LogicalCPUCoresPerPackage</key>
 			<integer>8</integer>
 			<key>ModelCode</key>
-			<string>MacBookPro11,3</string>
+			<string>MacBookPro11,2</string>
 			<key>ModelName</key>
 			<string>MacBook Pro</string>
 			<key>ModelUTI</key>
@@ -33,9 +33,9 @@
 			<key>NativeArchitecture</key>
 			<string>x86_64h</string>
 			<key>OperatingSystemVersion</key>
-			<string>10.11.5</string>
+			<string>10.11.6</string>
 			<key>OperatingSystemVersionWithBuildNumber</key>
-			<string>10.11.5 (15F34)</string>
+			<string>10.11.6 (15G31)</string>
 			<key>PhysicalCPUCoresPerPackage</key>
 			<integer>4</integer>
 			<key>Platform</key>
@@ -43,35 +43,35 @@
 				<key>Identifier</key>
 				<string>com.apple.platform.macosx</string>
 				<key>Name</key>
-				<string>OS X</string>
+				<string>macOS</string>
 			</dict>
 			<key>RAMSizeInMegabytes</key>
 			<integer>16384</integer>
 		</dict>
 		<key>Name</key>
-		<string>iPhone 6</string>
+		<string>iPhone SE</string>
 		<key>TargetArchitecture</key>
 		<string>x86_64</string>
 		<key>TargetDevice</key>
 		<dict>
 			<key>Identifier</key>
-			<string>C506E86B-40D9-43D2-95FB-CD0ADF799AAB</string>
+			<string>252CADC1-E488-4506-B293-892F59253C63</string>
 			<key>IsConcreteDevice</key>
 			<true/>
 			<key>ModelCode</key>
-			<string>iPhone7,2</string>
+			<string>iPhone8,4</string>
 			<key>ModelName</key>
-			<string>iPhone 6</string>
+			<string>iPhone SE</string>
 			<key>ModelUTI</key>
-			<string>com.apple.iphone-6-b4b5b9</string>
+			<string>com.apple.iphone-se-a1662-aeb1b8</string>
 			<key>Name</key>
-			<string>iPhone 6</string>
+			<string>iPhone SE</string>
 			<key>NativeArchitecture</key>
 			<string>x86_64</string>
 			<key>OperatingSystemVersion</key>
-			<string>9.3</string>
+			<string>10.0</string>
 			<key>OperatingSystemVersionWithBuildNumber</key>
-			<string>9.3 (13E230)</string>
+			<string>10.0 (14A5339a)</string>
 			<key>Platform</key>
 			<dict>
 				<key>Identifier</key>
@@ -83,20 +83,20 @@
 		<key>TargetSDK</key>
 		<dict>
 			<key>Identifier</key>
-			<string>iphonesimulator9.3</string>
+			<string>iphonesimulator10.0</string>
 			<key>IsInternal</key>
 			<false/>
 			<key>Name</key>
-			<string>Simulator - iOS 9.3</string>
+			<string>Simulator - iOS 10.0</string>
 			<key>OperatingSystemVersion</key>
-			<string>9.3</string>
+			<string>10.0</string>
 		</dict>
 	</dict>
 	<key>TestableSummaries</key>
 	<array>
 		<dict>
 			<key>ProjectPath</key>
-			<string>Themoji.xcodeproj</string>
+			<string>Trainer.xcodeproj</string>
 			<key>TargetName</key>
 			<string>Unit</string>
 			<key>TestName</key>
@@ -106,15 +106,23 @@
 			<key>Tests</key>
 			<array>
 				<dict>
+					<key>Duration</key>
+					<real>0.2951509952545166</real>
 					<key>Subtests</key>
 					<array>
 						<dict>
+							<key>Duration</key>
+							<real>0.29422104358673096</real>
 							<key>Subtests</key>
 							<array>
 								<dict>
+									<key>Duration</key>
+									<real>0.29356402158737183</real>
 									<key>Subtests</key>
 									<array>
 										<dict>
+											<key>Duration</key>
+											<real>0.0017129778861999512</real>
 											<key>TestIdentifier</key>
 											<string>Unit/testExample()</string>
 											<key>TestName</key>
@@ -124,9 +132,11 @@
 											<key>TestStatus</key>
 											<string>Success</string>
 											<key>TestSummaryGUID</key>
-											<string>307017AF-B8B5-4C61-9391-55C32AE57120</string>
+											<string>A2F04C2F-0CF9-4BEA-A858-117B4BEC546B</string>
 										</dict>
 										<dict>
+											<key>Duration</key>
+											<real>0.00030595064163208008</real>
 											<key>TestIdentifier</key>
 											<string>Unit/testExample2()</string>
 											<key>TestName</key>
@@ -136,9 +146,11 @@
 											<key>TestStatus</key>
 											<string>Success</string>
 											<key>TestSummaryGUID</key>
-											<string>02BAA520-D026-4170-A266-37325E470369</string>
+											<string>E48DE196-E883-475A-9034-561F4AFF84A3</string>
 										</dict>
 										<dict>
+											<key>Duration</key>
+											<real>0.29037696123123169</real>
 											<key>PerformanceMetrics</key>
 											<array>
 												<dict>
@@ -154,16 +166,16 @@
 													<real>0.10000000000000001</real>
 													<key>Measurements</key>
 													<array>
-														<real>4.2250000000000002e-06</real>
-														<real>1.1000000000000001e-06</real>
-														<real>4.9800000000000004e-07</real>
-														<real>4.9900000000000001e-07</real>
-														<real>3.7599999999999998e-07</real>
-														<real>3.9099999999999999e-07</real>
-														<real>3.7300000000000002e-07</real>
-														<real>3.8099999999999998e-07</real>
-														<real>3.77e-07</real>
-														<real>4.2399999999999999e-07</real>
+														<real>0.021794693</real>
+														<real>0.00055730899999999997</real>
+														<real>0.00055241000000000003</real>
+														<real>0.00055458799999999996</real>
+														<real>0.00055095199999999995</real>
+														<real>0.0012515930000000001</real>
+														<real>0.00088146999999999997</real>
+														<real>0.000487963</real>
+														<real>0.001376592</real>
+														<real>0.00043623400000000002</real>
 													</array>
 													<key>Name</key>
 													<string>Time</string>
@@ -180,7 +192,7 @@
 											<key>TestStatus</key>
 											<string>Success</string>
 											<key>TestSummaryGUID</key>
-											<string>DE485C5B-CFBF-4230-87E6-83B3194A4784</string>
+											<string>429978E6-5FE7-4D04-84CB-3EBCD08374AD</string>
 										</dict>
 									</array>
 									<key>TestIdentifier</key>

--- a/spec/fixtures/Valid2.plist
+++ b/spec/fixtures/Valid2.plist
@@ -107,22 +107,22 @@
 			<array>
 				<dict>
 					<key>Duration</key>
-					<real>0.2951509952545166</real>
+					<real>0.4</real>
 					<key>Subtests</key>
 					<array>
 						<dict>
 							<key>Duration</key>
-							<real>0.29422104358673096</real>
+							<real>0.4</real>
 							<key>Subtests</key>
 							<array>
 								<dict>
 									<key>Duration</key>
-									<real>0.29356402158737183</real>
+									<real>0.4</real>
 									<key>Subtests</key>
 									<array>
 										<dict>
 											<key>Duration</key>
-											<real>0.0017129778861999512</real>
+											<real>0.1</real>
 											<key>TestIdentifier</key>
 											<string>Unit/testExample()</string>
 											<key>TestName</key>
@@ -136,7 +136,7 @@
 										</dict>
 										<dict>
 											<key>Duration</key>
-											<real>0.00030595064163208008</real>
+											<real>0.1</real>
 											<key>TestIdentifier</key>
 											<string>Unit/testExample2()</string>
 											<key>TestName</key>
@@ -150,7 +150,7 @@
 										</dict>
 										<dict>
 											<key>Duration</key>
-											<real>0.29037696123123169</real>
+											<real>0.1</real>
 											<key>PerformanceMetrics</key>
 											<array>
 												<dict>
@@ -161,21 +161,21 @@
 													<key>MaxPercentRelativeStandardDeviation</key>
 													<integer>10</integer>
 													<key>MaxRegression</key>
-													<real>0.10000000000000001</real>
+													<real>0.1</real>
 													<key>MaxStandardDeviation</key>
-													<real>0.10000000000000001</real>
+													<real>0.1</real>
 													<key>Measurements</key>
 													<array>
 														<real>0.021794693</real>
-														<real>0.00055730899999999997</real>
-														<real>0.00055241000000000003</real>
-														<real>0.00055458799999999996</real>
-														<real>0.00055095199999999995</real>
-														<real>0.0012515930000000001</real>
-														<real>0.00088146999999999997</real>
+														<real>0.000557309</real>
+														<real>0.00055241</real>
+														<real>0.000554588</real>
+														<real>0.000550952</real>
+														<real>0.001251593</real>
+														<real>0.00088147</real>
 														<real>0.000487963</real>
 														<real>0.001376592</real>
-														<real>0.00043623400000000002</real>
+														<real>0.000436234</real>
 													</array>
 													<key>Name</key>
 													<string>Time</string>

--- a/spec/fixtures/Valid2.plist
+++ b/spec/fixtures/Valid2.plist
@@ -150,7 +150,7 @@
 										</dict>
 										<dict>
 											<key>Duration</key>
-											<real>0.1</real>
+											<real>0.2</real>
 											<key>PerformanceMetrics</key>
 											<array>
 												<dict>

--- a/spec/test_parser_spec.rb
+++ b/spec/test_parser_spec.rb
@@ -38,7 +38,7 @@ describe Trainer do
         tp = Trainer::TestParser.new("spec/fixtures/Valid1.plist")
         expect(tp.data).to eq([
                                 {
-                                  project_path: "Themoji.xcodeproj",
+                                  project_path: "Trainer.xcodeproj",
                                   target_name: "Unit",
                                   test_name: "Unit",
                                   tests: [
@@ -48,7 +48,7 @@ describe Trainer do
                                       name: "testExample()",
                                       object_class: "IDESchemeActionTestSummary",
                                       status: "Success",
-                                      guid: "4A24BFED-03E6-4FBE-BC5E-2D80023C06B4"
+                                      guid: "6840EEB8-3D7A-4B2D-9A45-6955DC11D32B"
                                     },
                                     {
                                       identifier: "Unit/testExample2()",
@@ -56,14 +56,14 @@ describe Trainer do
                                       name: "testExample2()",
                                       object_class: "IDESchemeActionTestSummary",
                                       status: "Failure",
-                                      guid: "B6AE5BAD-2F01-4D34-BEC8-6AB07472A13B",
+                                      guid: "B2EB311E-ED8D-4DAD-8AF0-A455A20855DF",
                                       failures: [
                                         {
-                                          file_name: "/Users/krausefx/Developer/themoji/Unit/Unit.swift",
-                                          line_number: 34,
+                                          file_name: "/Users/liamnichols/Code/Local/Trainer/Unit/Unit.swift",
+                                          line_number: 19,
                                           message: "XCTAssertTrue failed - ",
                                           performance_failure: false,
-                                          failure_message: "XCTAssertTrue failed - /Users/krausefx/Developer/themoji/Unit/Unit.swift:34"
+                                          failure_message: "XCTAssertTrue failed - /Users/liamnichols/Code/Local/Trainer/Unit/Unit.swift:19"
                                         }
                                       ]
                                     },
@@ -73,7 +73,7 @@ describe Trainer do
                                       name: "testPerformanceExample()",
                                       object_class: "IDESchemeActionTestSummary",
                                       status: "Success",
-                                      guid: "777C5F98-023B-4F99-B98D-20DDE724160E"
+                                      guid: "72D0B210-939D-4751-966F-986B6CB2660C"
                                     }
                                   ],
                                   number_of_tests: 3,

--- a/spec/test_parser_spec.rb
+++ b/spec/test_parser_spec.rb
@@ -41,6 +41,7 @@ describe Trainer do
                                   project_path: "Trainer.xcodeproj",
                                   target_name: "Unit",
                                   test_name: "Unit",
+                                  duration: "0.4",
                                   tests: [
                                     {
                                       identifier: "Unit/testExample()",
@@ -48,7 +49,8 @@ describe Trainer do
                                       name: "testExample()",
                                       object_class: "IDESchemeActionTestSummary",
                                       status: "Success",
-                                      guid: "6840EEB8-3D7A-4B2D-9A45-6955DC11D32B"
+                                      guid: "6840EEB8-3D7A-4B2D-9A45-6955DC11D32B",
+                                      duration: "0.1"
                                     },
                                     {
                                       identifier: "Unit/testExample2()",
@@ -57,6 +59,7 @@ describe Trainer do
                                       object_class: "IDESchemeActionTestSummary",
                                       status: "Failure",
                                       guid: "B2EB311E-ED8D-4DAD-8AF0-A455A20855DF",
+                                      duration: "0.1",
                                       failures: [
                                         {
                                           file_name: "/Users/liamnichols/Code/Local/Trainer/Unit/Unit.swift",
@@ -73,7 +76,8 @@ describe Trainer do
                                       name: "testPerformanceExample()",
                                       object_class: "IDESchemeActionTestSummary",
                                       status: "Success",
-                                      guid: "72D0B210-939D-4751-966F-986B6CB2660C"
+                                      guid: "72D0B210-939D-4751-966F-986B6CB2660C",
+                                      duration: "0.2"
                                     }
                                   ],
                                   number_of_tests: 3,

--- a/spec/test_parser_spec.rb
+++ b/spec/test_parser_spec.rb
@@ -41,7 +41,7 @@ describe Trainer do
                                   project_path: "Trainer.xcodeproj",
                                   target_name: "Unit",
                                   test_name: "Unit",
-                                  duration: "0.4",
+                                  duration: 0.4,
                                   tests: [
                                     {
                                       identifier: "Unit/testExample()",
@@ -50,7 +50,7 @@ describe Trainer do
                                       object_class: "IDESchemeActionTestSummary",
                                       status: "Success",
                                       guid: "6840EEB8-3D7A-4B2D-9A45-6955DC11D32B",
-                                      duration: "0.1"
+                                      duration: 0.1
                                     },
                                     {
                                       identifier: "Unit/testExample2()",
@@ -59,7 +59,7 @@ describe Trainer do
                                       object_class: "IDESchemeActionTestSummary",
                                       status: "Failure",
                                       guid: "B2EB311E-ED8D-4DAD-8AF0-A455A20855DF",
-                                      duration: "0.1",
+                                      duration: 0.1,
                                       failures: [
                                         {
                                           file_name: "/Users/liamnichols/Code/Local/Trainer/Unit/Unit.swift",
@@ -77,7 +77,7 @@ describe Trainer do
                                       object_class: "IDESchemeActionTestSummary",
                                       status: "Success",
                                       guid: "72D0B210-939D-4751-966F-986B6CB2660C",
-                                      duration: "0.2"
+                                      duration: 0.2
                                     }
                                   ],
                                   number_of_tests: 3,


### PR DESCRIPTION
Looks like the latest beta now includes the duration of the tests so i've added support :) 
The `time` attribute is now present on both the test case and suite in the junit ouput 🎉 

I also had to regenerate the `Valid1.plist` and `Valid2.plist` files from my own Xcode project so i've attached a copy incase anybody else needs to re-generate them in the future... Not sure if that should go into the repo though?

I've never really written any ruby before but the changes are minimal so it wasn't too hard but you might just want to sense check.. Tests all pass though.. Enjoy!

[Unit.xcodeproj.zip](https://github.com/KrauseFx/trainer/files/439669/Unit.xcodeproj.zip)
