### PR TITLE
Add space in failure message for readability

### DIFF
--- a/lib/trainer/test_parser.rb
+++ b/lib/trainer/test_parser.rb
@@ -127,7 +127,7 @@ module Trainer
                   line_number: current_failure['LineNumber'],
                   message: current_failure['Message'],
                   performance_failure: current_failure['PerformanceFailure'],
-                  failure_message: "#{current_failure['Message']}#{current_failure['FileName']}:#{current_failure['LineNumber']}"
+                  failure_message: "#{current_failure['Message']} (#{current_failure['FileName']}:#{current_failure['LineNumber']})"
                 }
               end
             end


### PR DESCRIPTION
Nothing fancy, just a space in the failure message. The failure reason was adjacent to the file name and line number, reports were hard to read.