### PR TITLE
Use target_name if available but fall back to test_name if it is not.

### DIFF
--- a/lib/assets/junit.xml.erb
+++ b/lib/assets/junit.xml.erb
@@ -6,7 +6,7 @@
 
 <testsuites tests="<%= number_of_tests %>" failures="<%= number_of_failures %>">
   <% @results.each do |testsuite| %>
-    <testsuite name=<%= testsuite[:target_name].encode(:xml => :attr) %> tests="<%= testsuite[:number_of_tests] %>" failures="<%= testsuite[:number_of_failures] %>" time="<%= testsuite[:duration] %>">
+    <testsuite name=<%= testsuite[:test_name].encode(:xml => :attr) %> tests="<%= testsuite[:number_of_tests] %>" failures="<%= testsuite[:number_of_failures] %>" time="<%= testsuite[:duration] %>">
       <% testsuite[:tests].each do |test| %>
         <testcase classname=<%= test[:test_group].encode(:xml => :attr) %> name=<%= test[:name].encode(:xml => :attr) %> time="<%= test[:duration] %>">
           <% (test[:failures] || []).each do |failure| %>

--- a/lib/assets/junit.xml.erb
+++ b/lib/assets/junit.xml.erb
@@ -6,7 +6,7 @@
 
 <testsuites tests="<%= number_of_tests %>" failures="<%= number_of_failures %>">
   <% @results.each do |testsuite| %>
-    <testsuite name=<%= (testsuite[:target_name] == nil ? testsuite[:test_name] : testsuite[:target_name]).encode(:xml => :attr) %> tests="<%= testsuite[:number_of_tests] %>" failures="<%= testsuite[:number_of_failures] %>" time="<%= testsuite[:duration] %>">
+    <testsuite name=<%= (testsuite[:target_name].nil? ? testsuite[:test_name] : testsuite[:target_name]).encode(:xml => :attr) %> tests="<%= testsuite[:number_of_tests] %>" failures="<%= testsuite[:number_of_failures] %>" time="<%= testsuite[:duration] %>">
       <% testsuite[:tests].each do |test| %>
         <testcase classname=<%= test[:test_group].encode(:xml => :attr) %> name=<%= test[:name].encode(:xml => :attr) %> time="<%= test[:duration] %>">
           <% (test[:failures] || []).each do |failure| %>

--- a/lib/assets/junit.xml.erb
+++ b/lib/assets/junit.xml.erb
@@ -6,7 +6,7 @@
 
 <testsuites tests="<%= number_of_tests %>" failures="<%= number_of_failures %>">
   <% @results.each do |testsuite| %>
-    <testsuite name=<%= testsuite[:test_name].encode(:xml => :attr) %> tests="<%= testsuite[:number_of_tests] %>" failures="<%= testsuite[:number_of_failures] %>" time="<%= testsuite[:duration] %>">
+    <testsuite name=<%= (testsuite[:target_name] == nil ? testsuite[:test_name] : testsuite[:target_name]).encode(:xml => :attr) %> tests="<%= testsuite[:number_of_tests] %>" failures="<%= testsuite[:number_of_failures] %>" time="<%= testsuite[:duration] %>">
       <% testsuite[:tests].each do |test| %>
         <testcase classname=<%= test[:test_group].encode(:xml => :attr) %> name=<%= test[:name].encode(:xml => :attr) %> time="<%= test[:duration] %>">
           <% (test[:failures] || []).each do |failure| %>


### PR DESCRIPTION
It turns out that target_name is not available when using xcodebuild test-without-building. test_name is always available though, so we can fall back to that. This ensures backward compatibility, although it looks like test_name could be used in any case (if both target_name and test_name are present, the values are the same).

(second pull request, I managed to delete the previous one when trying to fix a bad commit)