### PR TITLE
Fix comparison table in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Some Xcode versions has a known issue around not properly closing `stdout` ([Rad
 
 > By using `trainer`, the Twitter iOS code base now generates JUnit reports 10 times faster.
 
- | [xcpretty](https://github.com/supermarin/xcpretty) |  trainer
+| | [xcpretty](https://github.com/supermarin/xcpretty) |  trainer
 --------------------------|------------------------------|------------------------------
 Prettify the `xcodebuild` output | :white_check_mark: | :no_entry_sign:
 Generate JUnit reports | :white_check_mark: | :white_check_mark:


### PR DESCRIPTION
I think GitHub changed their Markdown renderer recently, this might be the reason why the table broke. This PR fixes it:

![screen shot 2017-04-14 at 19 58 09](https://cloud.githubusercontent.com/assets/1640908/25051403/b7e243b2-214c-11e7-8d57-8cccc254eeae.png)
