### PR TITLE
Add `fail_build` configuration

### DIFF
--- a/fastlane-plugin-trainer/lib/fastlane/plugin/trainer/actions/trainer_action.rb
+++ b/fastlane-plugin-trainer/lib/fastlane/plugin/trainer/actions/trainer_action.rb
@@ -7,9 +7,10 @@ module Fastlane
         params[:path] = Actions.lane_context[Actions::SharedValues::SCAN_GENERATED_PLIST_FILE] if Actions.lane_context[Actions::SharedValues::SCAN_GENERATED_PLIST_FILE]
         params[:path] ||= Actions.lane_context[Actions::SharedValues::SCAN_DERIVED_DATA_PATH] if Actions.lane_context[Actions::SharedValues::SCAN_DERIVED_DATA_PATH]
 
+        fail_build = params[:fail_build]
         resulting_paths = ::Trainer::TestParser.auto_convert(params)
         resulting_paths.each do |path, test_successful|
-          UI.test_failure!("Unit tests failed") unless test_successful
+          UI.test_failure!("Unit tests failed") if fail_build && !test_successful
         end
 
         return resulting_paths

--- a/lib/trainer/options.rb
+++ b/lib/trainer/options.rb
@@ -28,7 +28,12 @@ module Trainer
                                      env_name: "TRAINER_OUTPUT_DIRECTORY",
                                      default_value: nil,
                                      optional: true,
-                                     description: "Directoy in which the xml files should be written to. Same directory as source by default")
+                                     description: "Directoy in which the xml files should be written to. Same directory as source by default"),
+        FastlaneCore::ConfigItem.new(key: :fail_build,
+                                     env_name: "TRAINER_FAIL_BUILD",
+                                     description: "Should this step stop the build if the tests fail? Set this to false if you're handling this with a test reporter",
+                                     is_string: false,
+                                     default_value: true)
       ]
     end
   end


### PR DESCRIPTION
Similar to `fail_build` in scan, this defaults to true, which means scan will fail the build if unit tests fail. You can optionally set this option to false if you're handling this outside Fastlane.

This behaviour is helpful when you're using a reporting step on your CI pipeline, which will set the job status depending on the results of the report publishing.

For instance, on Jenkins:

```groovy
pipeline {
  stages {
    stage('Build') {
      steps {
        sh 'bundle exec fastlane build'
      }
    }

    stage('Run unit tests') {
      steps {
        sh 'bundle exec fastlane test'
      }
    }
  }

  post {
    success {
      junit(testResults: '*_TestSummaries.xml') // This will set the job to unstable if unit tests failed
    }
  }
}

```