### PR TITLE
Add Xcode 10 support

### DIFF
--- a/lib/trainer/test_parser.rb
+++ b/lib/trainer/test_parser.rb
@@ -13,9 +13,14 @@ module Trainer
                                              title: "Summary for trainer #{Trainer::VERSION}")
 
       containing_dir = config[:path]
+      # Xcode < 10
       files = Dir["#{containing_dir}/**/Logs/Test/*TestSummaries.plist"]
       files += Dir["#{containing_dir}/Test/*TestSummaries.plist"]
       files += Dir["#{containing_dir}/*TestSummaries.plist"]
+      # Xcode 10
+      files += Dir["#{containing_dir}/**/Logs/Test/*.xcresult/TestSummaries.plist"]
+      files += Dir["#{containing_dir}/Test/*.xcresult/TestSummaries.plist"]
+      files += Dir["#{containing_dir}/*.xcresult/TestSummaries.plist"]
       files += Dir[containing_dir] if containing_dir.end_with?(".plist") # if it's the exact path to a plist file
 
       if files.empty?


### PR DESCRIPTION
Xcode 10 creates a folder ending in `.xcresult` for every test run. Inside of that folder is the `TestSummaries.plist` file.